### PR TITLE
Add --address option to dspserver

### DIFF
--- a/trunk/src/dspserver/client.c
+++ b/trunk/src/dspserver/client.c
@@ -990,7 +990,8 @@ void* client_thread(void* arg) {
 
     memset(&server,0,sizeof(server));
     server.sin_family=AF_INET;
-    server.sin_addr.s_addr=htonl(INADDR_ANY);
+    fprintf(stderr,"client_thread: server socket address: %s\n", INADDR_DSPSERVER);    
+    server.sin_addr.s_addr=inet_addr(INADDR_DSPSERVER);
     server.sin_port=htons(port);
 
     if(bind(serverSocket,(struct sockaddr *)&server,sizeof(server))<0) {
@@ -1009,7 +1010,8 @@ void* client_thread(void* arg) {
     // setting up ssl server
     memset(&server_ssl,0,sizeof(server_ssl));
     server_ssl.sin_family=AF_INET;
-    server_ssl.sin_addr.s_addr=htonl(INADDR_ANY);
+    fprintf(stderr,"client_thread: server SSL socket address: %s\n", INADDR_DSPSERVER);     
+    server_ssl.sin_addr.s_addr=inet_addr(INADDR_DSPSERVER);
     server_ssl.sin_port=htons(port_ssl);
 
     ctx = evssl_init();

--- a/trunk/src/dspserver/client.h
+++ b/trunk/src/dspserver/client.h
@@ -130,4 +130,7 @@ static SSL_CTX *evssl_init(void);
 
 extern double mic_src_ratio;
 
+extern struct dspserver_config config;
+#define INADDR_DSPSERVER config.dspserver_address
+
 #endif

--- a/trunk/src/dspserver/main.c
+++ b/trunk/src/dspserver/main.c
@@ -234,7 +234,7 @@ void processCommands(int argc,char** argv,struct dspserver_config *config) {
                 fprintf(stderr,"Usage: \n");
                 fprintf(stderr,"  dspserver --receiver N (default 0)\n");
                 fprintf(stderr,"            --server 0.0.0.0 (default 127.0.0.1)\n");
-                fprintf(stderr,"            --address 0.0.0.0 (default 127.0.0.1)\n");
+                fprintf(stderr,"            --address 0.0.0.0 (default is any address, i.e. 0.0.0.0)\n");
                 fprintf(stderr,"            --soundcard (machine dependent)\n");
                 fprintf(stderr,"            --offset 0 \n");
                 fprintf(stderr,"            --share (will register this server for other users \n");
@@ -273,7 +273,7 @@ int main(int argc,char* argv[]) {
     char directory[MAXPATHLEN];
     strcpy(config.soundCardName,"HPSDR");
     strcpy(config.server_address,"127.0.0.1"); // localhost
-    strcpy(config.dspserver_address,"127.0.0.1"); // localhost
+    strcpy(config.dspserver_address,"0.0.0.0"); // any address
     strcpy(config.share_config_file, getenv("HOME"));
     strcat(config.share_config_file, "/dspserver.conf");
     processCommands(argc,argv,&config);

--- a/trunk/src/dspserver/main.h
+++ b/trunk/src/dspserver/main.h
@@ -38,6 +38,7 @@ struct dspserver_config {
     int offset;
     char share_config_file[MAXPATHLEN];
     char server_address[256];
+    char dspserver_address[256];
     int thread_debug;
     int no_correct_iq;
 };

--- a/trunk/src/dspserver/ozy.h
+++ b/trunk/src/dspserver/ozy.h
@@ -96,7 +96,7 @@ int lastMode;
 * 
 * @return 
 */
-extern int ozy_init(const char *server_address);
+extern int ozy_init(const char *server_address, const char *dspserver_address);
 
 
 /* --------------------------------------------------------------------------*/

--- a/trunk/src/dspserver/rtp.c
+++ b/trunk/src/dspserver/rtp.c
@@ -55,6 +55,8 @@
 #endif
 
 #include "rtp.h"
+#include "client.h"
+#include "main.h"
 
 unsigned int recv_ts=0;
 unsigned int send_ts=0;
@@ -94,9 +96,9 @@ RtpSession *rtpSession;
     rtp_session_set_blocking_mode(rtpSession,FALSE);
 
 #ifdef HAVE_RTCP_ORTP
-    rtp_session_set_local_addr(rtpSession,"0.0.0.0",LOCAL_RTP_PORT,LOCAL_RTCP_PORT);
+    rtp_session_set_local_addr(rtpSession,INADDR_DSPSERVER,LOCAL_RTP_PORT,LOCAL_RTCP_PORT);
 #else
-    rtp_session_set_local_addr(rtpSession,"0.0.0.0",LOCAL_RTP_PORT);
+    rtp_session_set_local_addr(rtpSession,INADDR_DSPSERVER,LOCAL_RTP_PORT);
 #endif
     rtp_session_set_remote_addr(rtpSession, remote_addr, remote_port );
 


### PR DESCRIPTION
Add --address option to dspserver, enabling multiple instances to be run on the same host, by binding to the specifed address only. The default remains as 0.0.0.0,