### PR TITLE
Adds rigctl-port option to QtRadio, refactors options to use QCommandLineParser

### DIFF
--- a/trunk/src/QtRadio/UI.cpp
+++ b/trunk/src/QtRadio/UI.cpp
@@ -64,13 +64,13 @@
 #include "Frequency.h"
 #include "EqualizerDialog.h"
 
-UI::UI(const QString server) {
+UI::UI(const QString server, unsigned short rigctl_port) {
 
     widget.setupUi(this);
     servers = 0;
     pHwDlg = 0;
     meter = -121;
-    initRigCtl();
+    initRigCtl(rigctl_port);
     fprintf(stderr, "rigctl: Calling init\n");
     servername = "Unknown";
     configure.thisuser = "None";
@@ -2437,9 +2437,9 @@ void UI::printStatusBar(QString message)
     lastFreq = frequency;
 }
 
-void UI::initRigCtl ()
+void UI::initRigCtl(unsigned short rigctl_port)
 {
-    rigCtl = new RigCtlServer ( this, this );
+    rigCtl = new RigCtlServer ( this, this, rigctl_port );
 }
 
 long long UI::rigctlGetFreq()

--- a/trunk/src/QtRadio/UI.h
+++ b/trunk/src/QtRadio/UI.h
@@ -90,7 +90,7 @@
 class UI : public QMainWindow {
     Q_OBJECT
 public:
-    UI(const QString server = QString(""));
+    UI(const QString server = QString(""), unsigned short rigctl_port = RigCtlServer::RIGCTL_PORT);
     virtual ~UI();
     void loadSettings();
     void saveSettings();
@@ -345,7 +345,7 @@ private:
     void setSubRxPan();
     void actionGain(int g);
     void setGain(bool state);
-    void initRigCtl();
+    void initRigCtl(unsigned short);
     void setPwsMode(int mode); //KD0OSS
     RigCtlServer *rigCtl;
     QString getversionstring();

--- a/trunk/src/QtRadio/UI.h
+++ b/trunk/src/QtRadio/UI.h
@@ -345,7 +345,7 @@ private:
     void setSubRxPan();
     void actionGain(int g);
     void setGain(bool state);
-    void initRigCtl(unsigned short);
+    void initRigCtl(unsigned short rigctl_port);
     void setPwsMode(int mode); //KD0OSS
     RigCtlServer *rigCtl;
     QString getversionstring();

--- a/trunk/src/QtRadio/main.cpp
+++ b/trunk/src/QtRadio/main.cpp
@@ -30,6 +30,8 @@
 #include <QApplication>
 #endif
 
+#include <QCommandLineParser>
+
 #include "UI.h"
 
 #include <stdio.h>
@@ -94,17 +96,32 @@ int main(int argc, char *argv[]) {
 
     qDebug() << "QThread: Main GUI thread : " << app.thread()->currentThread();
 
-    //trying to get the arguments into a list    
-    QStringList args = app.arguments();
+    QCommandLineParser parser;
+    parser.setApplicationDescription("QtRadio");
+    parser.addHelpOption();
 
-    for (int i = 0; i < args.size(); ++i)
-         fprintf (stderr, "%d: %s\n", i,  args.at(i).toLocal8Bit().constData() );
-     
-    QString srv("");
+    // the server option
+    QCommandLineOption serverAddressOption(QStringList() << "s" << "server-address",
+            "Connect to server SERVER_ADDRESS, default none.",
+            "SERVER_ADDRESS", "");
+    parser.addOption(serverAddressOption);
 
-    if ( args.size() >1 ) srv = args.at(1) ;
+    // the address option
+    QCommandLineOption rigctlPortOption(QStringList() << "r" << "rigctl-port",
+            "Listen on port RIGCTL_PORT for rigctl clients, default "+
+            QString::number(RigCtlServer::RIGCTL_PORT)+".",
+            "RIGCTL_PORT", QString::number(RigCtlServer::RIGCTL_PORT));
+    parser.addOption(rigctlPortOption);
+
+    // Process the actual command line arguments given by the user
+    parser.process(app);
+
+    // provide some default values
+    QString srv((parser.isSet(serverAddressOption))?parser.value(serverAddressOption):"");
+    QString rigctl((parser.isSet(rigctlPortOption))?parser.value(rigctlPortOption):QString::number(RigCtlServer::RIGCTL_PORT));
+
     // create and show your widgets here
-    UI widget(srv);
+    UI widget(srv, rigctl.toUShort());
 
     widget.show();
     return app.exec();

--- a/trunk/src/QtRadio/rigctl.cpp
+++ b/trunk/src/QtRadio/rigctl.cpp
@@ -401,15 +401,17 @@ void RigCtlSocket::readyRead() {
         }
 }
 
-RigCtlServer::RigCtlServer(QObject *parent, UI *main)
+const unsigned short RigCtlServer::RIGCTL_PORT(19090);
+
+RigCtlServer::RigCtlServer(QObject *parent, UI *main,  unsigned short rigctl_port)
         : QObject(parent),
           main(main) {
         server = new QTcpServer(this);
-        if (!server->listen(QHostAddress::Any, 19090)) { // or listen(QHostAddress::LocalHost, 19090)) {
-                fprintf(stderr, "rigctl: failed to bind socket\n");
+        if (!server->listen(QHostAddress::Any, rigctl_port)) {
+                fprintf(stderr, "rigctl: failed to bind socket on port %d\n", rigctl_port);
                 return;
         }
-        fprintf(stderr, "rigctl: Listening\n");
+        fprintf(stderr, "rigctl: Listening on port %d\n", rigctl_port);
         connect(server, SIGNAL(newConnection()), this, SLOT(newConnection()));
 }
 

--- a/trunk/src/QtRadio/rigctl.h
+++ b/trunk/src/QtRadio/rigctl.h
@@ -5,7 +5,6 @@
 #include <QtNetwork/QTcpServer>
 #include <QtNetwork/QTcpSocket>
 
-
 class UI;
 
 class RigCtlSocket : public QObject {
@@ -28,7 +27,8 @@ class RigCtlServer : public QObject {
         Q_OBJECT
 
         public:
-                RigCtlServer(QObject *parent = 0, UI *main = 0);
+                RigCtlServer(QObject *parent = 0, UI *main = 0, unsigned short rigctl_port = RIGCTL_PORT);
+                static const unsigned short RIGCTL_PORT;
 
         public slots:
                 void newConnection(void);


### PR DESCRIPTION
I have modfied QtRadio to take a command line argument --rigctl-port specifying the port for rigctld emulation.  I added the --server-address option to replace the old option/argument.  This now allows multiple instances of QtRadio to run on the same host supporting distinct hamlib clients, such as fldigi, wsjtx, etc. This is especially useful for wsjtx as it doesn't seem to support configurable ports for the rigctld rig model, so QtRadio can be told to operate on the default rigctld port 4532. The default rigctl-port of 19090 ensures backwards compatibility, although users will now need to explicitly use -s or --server-address when specifying a dspserver address for initial connection.

Qtradio help now shows (a little more tidily with monospace fonts):

Usage: QtRadio [options]
QtRadio

Options:
  -h, --help                             Displays this help.
  -s, --server-address <SERVER_ADDRESS>  Connect to server SERVER_ADDRESS,
                                         default none.
  -r, --rigctl-port <RIGCTL_PORT>        Listen on port RIGCTL_PORT for rigctl
                                         clients, default 19090.

Future work: It would be nice to display the rigctl-port in use in the QtRadio GUI so a user may easily determine what port to use in hamlib clients without the need to actually remember the port they specified on the command line or determine it by other means.