### PR TITLE
Adds support for "--soundcard U7_KX3" and "--soundcard FCDProPlus" options

### DIFF
--- a/trunk/src/dspserver/soundcard.c
+++ b/trunk/src/dspserver/soundcard.c
@@ -83,6 +83,20 @@ fprintf(stderr,"setSoundcard: %d\n",card);
             multimeterCalibrationOffset=-240.0f - 25.0f;
             displayCalibrationOffset=-240.0f - 18.0f;
             break;
+        case U7_KX3:
+            // G0HWW's figs - XG3 @ -73dBm for S9
+            // into KX3 with preamp +20dB and Asus XONAR U7
+            // with 2700Hz bandwidth - best effort calibration
+            multimeterCalibrationOffset=  -73.0f - 5.0f;
+            displayCalibrationOffset=  -107.31f + 20.0f;
+            break;
+        case FCDProPlus:
+            // G0HWW's figs - XG3 @ -73dBm for S9
+            // into fcdpp-server.py with gains: -p -m -i 0
+            // with 2700Hz bandwidth - best effort calibration
+            multimeterCalibrationOffset=  -73.0f -10.0f;
+            displayCalibrationOffset=  -107.31f + 15.0f;
+            break;
     }
 
     fprintf(stderr,"setSoundcard %f %f\n",multimeterCalibrationOffset,displayCalibrationOffset);
@@ -117,6 +131,10 @@ int getSoundcardId(char* name) {
         id=HPSDR;
     } else if(strcmp(name,"SDR-IQ")==0) {
         id=SDR_IQ;
+    } else if(strcmp(name,"U7_KX3")==0) {
+        id=U7_KX3;
+    } else if(strcmp(name,"FCDProPlus")==0) {
+        id=FCDProPlus;
     }
 fprintf(stderr,"getSoundcardId: %s id=%d\n",name,id);
     return id;

--- a/trunk/src/dspserver/soundcard.h
+++ b/trunk/src/dspserver/soundcard.h
@@ -38,6 +38,8 @@
 #define UNSUPPORTED_CARD 7
 #define HPSDR 8
 #define SDR_IQ 9
+#define U7_KX3 10
+#define FCDProPlus 11
 
 int soundcard;
 


### PR DESCRIPTION
This change adds support for "--soundcard U7_KX3" and "--soundcard FCDProPlus" option values to dspserver. Provides s-meter and power spectrum scaling/fudge-factor values for both soundcard profiles.  These values were determined using an Elecraft XG3 signal generator and are considered to be roughly right, on most bands from 160m to 10m. The KX3 was used with kx3-server.py
using an Asus Xonar U7 USB soundcard, sampliing at 96kHz. It's calibration is pretty good from 80m to 10m but is about 1/2 an s-point (3dB) down on top band.  The FCDPro+ was used with fcdpp-server.py with gain options -l -m -i 0.  The FCDPro+ seems to be about 2 s-points (12dB) down on 80m - it does seems to be deaf there!