### PR TITLE
Adjust USB / LSB passbands

### DIFF
--- a/README
+++ b/README
@@ -5,7 +5,8 @@ http://openhpsdr.org/wiki/index.php?title=Ghpsdr3
 Changes in the AB9IL fork:
   1)  FM filter bandwidths increased up to 200 kHz.
   2)  FM demodulator bandwidth increased to 200 kHz.
-
+  3)  LSB / USB filter passbands adjusted for crisper response when narrow and deeper lows when wide.
+  
 Highlights of some of the many other changes:
 
 softrock     - Rx and Tx.  Pulse and Jack audio.  Connects up to 4 radios using Jack.  Works with all softrocks.

--- a/trunk/src/QtRadio/LSBFilters.cpp
+++ b/trunk/src/QtRadio/LSBFilters.cpp
@@ -30,17 +30,17 @@
 
 LSBFilters::LSBFilters() {
 
-    filters[0].init("5.0k",-5150,-150);
-    filters[1].init("4.4k",-4550,-150);
-    filters[2].init("3.8k",-3950,-150);
+    filters[0].init("5.0k",-5050,-50);
+    filters[1].init("4.4k",-4450,-50);
+    filters[2].init("3.8k",-3900,-100);
     filters[3].init("3.3k",-3450,-150);
     filters[4].init("2.9k",-3050,-150);
-    filters[5].init("2.7k",-2850,-150);
-    filters[6].init("2.4k",-2550,-150);
-    filters[7].init("2.1k",-2250,-150);
-    filters[8].init("1.8k",-1950,-150);
-    filters[9].init("1.0k",-1150,-150);
-    filters[10].init("Vari",-2550,-150);
+    filters[5].init("2.7k",-2900,-200);
+    filters[6].init("2.4k",-2600,-200);
+    filters[7].init("2.1k",-2400,-300);
+    filters[8].init("1.8k",-2150,-350);
+    filters[9].init("1.0k",-1400,-400);
+    filters[10].init("Vari",-5050,-50);
 
     selectFilter(3);
 }

--- a/trunk/src/QtRadio/USBFilters.cpp
+++ b/trunk/src/QtRadio/USBFilters.cpp
@@ -30,17 +30,17 @@
 USBFilters::USBFilters() {
     qDebug() << "USBFilters";
 
-    filters[0].init("5.0k",150,5150);
-    filters[1].init("4.4k",150,4550);
-    filters[2].init("3.8k",150,3950);
+    filters[0].init("5.0k",50,5050);
+    filters[1].init("4.4k",50,4450);
+    filters[2].init("3.8k",100,3900);
     filters[3].init("3.3k",150,3450);
     filters[4].init("2.9k",150,3050);
-    filters[5].init("2.7k",150,2850);
-    filters[6].init("2.4k",150,2550);
-    filters[7].init("2.1k",150,2250);
-    filters[8].init("1.8k",150,1950);
-    filters[9].init("1.0k",150,1150);
-    filters[10].init("Vari",150,2550);
+    filters[5].init("2.7k",200,2900);
+    filters[6].init("2.4k",200,2600);
+    filters[7].init("2.1k",300,2400);
+    filters[8].init("1.8k",350,2150);
+    filters[9].init("1.0k",400,1400);
+    filters[10].init("Vari",50,5050);
 
     selectFilter(3);
 }


### PR DESCRIPTION
Passband edges in files USBFilters.cpp and LSBFilters.cpp were adjusted for a more balanced response depending on the width selected.  There's more cutting of lows in narrow settings and more passage of lows in wide settings.