### PR TITLE
Buffer length, LSB filters.

### DIFF
--- a/trunk/src/QtRadio/LSBFilters.cpp
+++ b/trunk/src/QtRadio/LSBFilters.cpp
@@ -31,7 +31,7 @@
 LSBFilters::LSBFilters() {
     qDebug() << "LSBFilters";
     
-    filters[0].init("7.0k",-7075,75);
+    filters[0].init("7.0k",-7075,-75);
     filters[1].init("5.0k",-5075,-75);
     filters[2].init("4.4k",-4475,-75);
     filters[3].init("3.8k",-3900,-100);

--- a/trunk/src/QtRadio/LSBFilters.cpp
+++ b/trunk/src/QtRadio/LSBFilters.cpp
@@ -30,10 +30,10 @@
 
 LSBFilters::LSBFilters() {
     qDebug() << "LSBFilters";
-
-    filters[0].init("7.0k",-7050,50);
-    filters[1].init("5.0k",-5050,-50);
-    filters[2].init("4.4k",-4450,-50);
+    
+    filters[0].init("7.0k",-7075,75);
+    filters[1].init("5.0k",-5075,-75);
+    filters[2].init("4.4k",-4475,-75);
     filters[3].init("3.8k",-3900,-100);
     filters[4].init("3.3k",-3450,-150);
     filters[5].init("2.9k",-3050,-150);
@@ -41,7 +41,7 @@ LSBFilters::LSBFilters() {
     filters[7].init("2.4k",-2700,-300);
     filters[8].init("2.1k",-2450,-350);
     filters[9].init("1.7k",-2100,-400);
-    filters[10].init("Vari",-5050,-50);
+    filters[10].init("Vari",-7075,-75);
 
     selectFilter(4);
 }

--- a/trunk/src/rtlsdr/client.cpp
+++ b/trunk/src/rtlsdr/client.cpp
@@ -164,7 +164,7 @@ void *helper_thread (void *arg)
         // int r = rtlsdr_wait_async(pRec->cfg.rtl, user_data_callback, pRec);
         int r = rtlsdr_read_async(pRec->cfg.rtl, user_data_callback, pRec,
                                   1,    // buf_num,
-                                  32768  // uint32_t buf_len
+                                  16384  // uint32_t buf_len
                                   );
         if ( r < 0) {
             printf(" !!!!!!!!! wait async input error: [%d]\n", r );


### PR DESCRIPTION
Buffer length in the rtl-sdr client is set back to 16384.  LSB filtering is adjusted.